### PR TITLE
添加监控命令行，增加U2截图，及状态恢复

### DIFF
--- a/src/common.py
+++ b/src/common.py
@@ -1,10 +1,9 @@
 from .utils.signal import signal
 from datetime import datetime
 
-
-
 # 存储 全局共享 数据
 GSTORE = {}
+
 
 def INFO(info):
     """
@@ -16,7 +15,8 @@ def INFO(info):
     """
     signal.info(f'{info}')
 
-def STEP(stepNo:int,desc:str):
+
+def STEP(stepNo: int, desc: str):
     """
     在日志和测试报告中打印出 测试步骤说明，
     使得 运行报告更加清晰
@@ -25,23 +25,36 @@ def STEP(stepNo:int,desc:str):
     @param stepNo : 指定 是第几步
     @param desc :   步骤描述
     """
-    signal.step(stepNo,desc)
+    signal.step(stepNo, desc)
 
 
-def CHECK_POINT(desc:str, condition):
+def CHECK_POINT(desc: str, condition, screen_shot=None, driver=None, screen_name=None, width=None):
     """
     检查点
 
     参数：
+    @param width: 图片html 显示宽度， 可以是 50% / 800px / 30em 这些格式
+    @param screen_name: 截图名
+    @param driver: driver对象
     @param desc :   检查点文字描述
     @param condition ： 检查点 表达式
+    @param screen_shot ： 如果检查错误，需要截屏，传截图方式类型 U,A,S
     """
-
     if condition:
         signal.checkpoint_pass(desc)
     else:
         signal.checkpoint_fail(desc)
+        # 如果需要截屏
+        if screen_shot is not None:
+            # u2 appium selenium
+            assert screen_shot in ['U', 'A', 'S']
+            if screen_shot in ['S','A'] :
+                # appium 跟selenium一个样
+                SELENIUM_LOG_SCREEN(driver, screen_name, width)
+            else:
+                U2_SCREEN_SHOT(driver, screen_name, width)
         raise AssertionError()
+
 
 def LOG_IMG(imgPath: str, width: str = None):
     """
@@ -54,15 +67,27 @@ def LOG_IMG(imgPath: str, width: str = None):
     signal.log_img(imgPath, width)
 
 
-def SELENIUM_LOG_SCREEN(driver, width: str = None):
+def SELENIUM_LOG_SCREEN(driver, filename, width: str = None):
     """
     在日志中加入selenium控制的 浏览器截屏图片
 
+    @param filename: 图片名
     @param driver: selenium webdriver对象
     @param width:  图片html 显示宽度， 可以是 50% / 800px / 30em 这些格式
     """
-    filename = datetime.now().strftime('%Y%m%d%H%M%S%f')
+    if not filename:
+        filename = datetime.now().strftime('%Y%m%d%H%M%S%f')
     filepath = f'log/imgs/{filename}.png'
     filepath_relative_to_log = f'imgs/{filename}.png'
     driver.get_screenshot_as_file(filepath)
     signal.log_img(filepath_relative_to_log, width)
+
+
+def U2_SCREEN_SHOT(driver, filename, width=None):
+    # 插入截图
+    if not filename:
+        filename = datetime.now().strftime('%Y%m%d%H%M%S%f')
+    filepath = f'log/imgs/{filename}.png'
+    filepath_relative_to_log = f'imgs/{filename}.png'
+    driver.screenshot(filepath)
+    signal.log_img(filepath_relative_to_log, '30%' if not width else width)

--- a/src/run.py
+++ b/src/run.py
@@ -1,5 +1,18 @@
-import argparse,re,os
+import argparse, re, os
 from .product import version
+import importlib.util
+import threading
+
+
+def register_watch(module, filepath):
+    spec = importlib.util.spec_from_file_location(module, filepath)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    watches = []
+    for (name, item) in module.__dict__.items():
+        if name.startswith('watch'):
+            watches.append(item)
+    return watches
 
 
 def tagExpressionGen(argstr):
@@ -7,7 +20,7 @@ def tagExpressionGen(argstr):
     for part in argstr:
         # 有单引号，是表达式
         if "'" in part:
-            rule = re.sub(r"'.+?'", lambda m :f'tagmatch({m.group(0)})' , part)
+            rule = re.sub(r"'.+?'", lambda m: f'tagmatch({m.group(0)})', part)
             tagRules.append(f'({rule})')
         # 是简单标签名
         else:
@@ -15,10 +28,11 @@ def tagExpressionGen(argstr):
             tagRules.append(f'{rule}')
     return ' or '.join(tagRules)
 
-def run() :
+
+def run():
     parser = argparse.ArgumentParser()
-    parser.add_argument('--version', action='version', version=f'hytest v{version}',help="显示版本号" )
-    parser.add_argument('--new',  metavar='project_dir', help="创建新项目目录" )
+    parser.add_argument('--version', action='version', version=f'hytest v{version}', help="显示版本号")
+    parser.add_argument('--new', metavar='project_dir', help="创建新项目目录")
     parser.add_argument("case_dir", help="用例根目录", nargs='?', default='cases')
     parser.add_argument("-L", "--loglevel", metavar='Level_Number', type=int, help="日志级别  0:低 - 1:高", default=0)
 
@@ -26,24 +40,34 @@ def run() :
     parser.add_argument("--suite", metavar='Suite_Name', action='append', help="套件名过滤，支持通配符", default=[])
     parser.add_argument("--tag", metavar='Tag_Expression', action='append', help="标签名过滤，支持通配符", default=[])
     parser.add_argument("--tagnot", metavar='Tag_Expression', action='append', help="标签名过滤，支持通配符", default=[])
-    parser.add_argument("-A", "--argfile", metavar='Argument_File', help="参数文件", type=argparse.FileType('r', encoding='utf8'))
-
+    parser.add_argument("-A", "--argfile", metavar='Argument_File', help="参数文件",
+                        type=argparse.FileType('r', encoding='utf8'))
+    parser.add_argument('-W', "--watch", nargs='?', help="多线程监控")
 
     args = parser.parse_args()
+
+    event = threading.Event()
+    if args.watch:
+        watch_list = register_watch('watch', args.watch)
+        event.set()
+        for item in watch_list:
+            t = threading.Thread(target=item, args=(event,))
+            t.start()
+    else:
+        watch_list = None
     # 有参数放在文件中
     if args.argfile:
-        fileArgs = [para for para in args.argfile.read().replace('\n',' ').split() if para]
-        print(fileArgs)
-        args = parser.parse_args(fileArgs,args)
+        fileArgs = [para for para in args.argfile.read().replace('\n', ' ').split() if para]
+        args = parser.parse_args(fileArgs, args)
 
     # 创建项目目录
     if args.new:
-        projDir =  args.new
+        projDir = args.new
         if os.path.exists(projDir):
             print(f'{projDir} already exists！')
             exit(2)
         os.makedirs(f'{projDir}/cases')
-        with open(f'{projDir}/cases/case1.py','w',encoding='utf8') as f:
+        with open(f'{projDir}/cases/case1.py', 'w', encoding='utf8') as f:
             f.write('''class c1:
     name = '用例名称 - 0001'
 
@@ -52,14 +76,13 @@ def run() :
 
         exit()
 
-
-    if not os.path.exists(args.case_dir) :
+    if not os.path.exists(args.case_dir):
         print(f' {args.case_dir} 目录不存在，工作目录为：{os.getcwd()}')
-        exit(2)  #  2 表示没有可以执行的用例
+        exit(2)  # 2 表示没有可以执行的用例
 
-    if not os.path.isdir(args.case_dir) :
+    if not os.path.isdir(args.case_dir):
         print(f' {args.case_dir} 不是目录，工作目录为：{os.getcwd()}')
-        exit(2) #  2 表示没有可以执行的用例
+        exit(2)  # 2 表示没有可以执行的用例
 
     # 同时执行log里面的初始化日志模块，注册signal的代码
     from .utils.log import LogLevel
@@ -68,9 +91,7 @@ def run() :
     LogLevel.level = args.loglevel
     # print('loglevel',LogLevel.level)
 
-
     # --tag "'冒烟测试' and 'UITest' or (not '快速' and 'fast')" --tag 白月 --tag 黑羽
-
 
     tag_include_expr = tagExpressionGen(args.tag)
     tag_exclude_expr = tagExpressionGen(args.tagnot)
@@ -78,13 +99,12 @@ def run() :
     # print(tag_include_expr)
     # print(tag_exclude_expr)
 
-
     print(f'''           
     *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *     
     *       hytest {version}            www.byhy.net   *
     *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *
     '''
-    )
+          )
 
     os.makedirs('log/imgs', exist_ok=True)
 
@@ -94,10 +114,13 @@ def run() :
         casename_filters=args.test,
         tag_include_expr=tag_include_expr,
         tag_exclude_expr=tag_exclude_expr,
-        )
+    )
 
     # 0 表示执行成功 , 1 表示有错误 ， 2 表示没有可以执行的用例
-    return Runner.run()
+    result = Runner.run()
+    if watch_list:
+        event.clear()
+    return result
 
 
 if __name__ == '__main__':

--- a/src/run.py
+++ b/src/run.py
@@ -49,9 +49,9 @@ def run():
     event = threading.Event()
     if args.watch:
         watch_list = register_watch('watch', args.watch)
-        event.set()
         for item in watch_list:
             t = threading.Thread(target=item, args=(event,))
+            t.setDaemon(True)
             t.start()
     else:
         watch_list = None
@@ -116,11 +116,22 @@ def run():
         tag_exclude_expr=tag_exclude_expr,
     )
 
-    # 0 表示执行成功 , 1 表示有错误 ， 2 表示没有可以执行的用例
-    result = Runner.run()
+    # 0 表示执行成功 , 1 表示有错误 ， 2 表示没有可以执行的用例,3 表示网页或APP崩溃恢复原状失败
+    result = []  # 懒得重写thread 就传list拿结果
+    t = threading.Thread(target=Runner.run, args=(result, event))
+    t.setDaemon(True)
+    t.start()
+    try:
+        while t.is_alive():
+            pass
+    except:
+        print('Stopped by keyboard')
+
     if watch_list:
         event.clear()
-    return result
+    if not result:
+        return 0
+    return result[0]
 
 
 if __name__ == '__main__':

--- a/src/utils/log.py
+++ b/src/utils/log.py
@@ -1,163 +1,408 @@
-_e=' case_st_lable'
-_d='green'
-_c='case_abort_list'
-_b='case_fail_list'
-_a='case_pass_list'
-_Z='tag'
-_Y=' fail'
-_X='folder_header'
-_W='executetime'
-_V='folder_body'
-_U='%Y%m%d_%H%M%S'
-_T='用例'
-_S='log'
-_R='info error-info'
-_Q='%Y-%m-%d %H:%M:%S'
-_P='utf8'
-_O='label'
-_N='suite'
-_M='class'
-_L='case_teardown_fail'
-_K='suite_teardown_fail'
-_J='case_setup_fail'
-_I='suite_setup_fail'
-_H='case_pass'
-_G='\n'
-_F='Traceback:\n'
-_E='case_abort'
-_D='case_fail'
-_C='case_count'
-_B='bright_red'
-_A=None
-import logging,os,time
+_e = ' case_st_lable'
+_d = 'green'
+_c = 'case_abort_list'
+_b = 'case_fail_list'
+_a = 'case_pass_list'
+_Z = 'tag'
+_Y = ' fail'
+_X = 'folder_header'
+_W = 'executetime'
+_V = 'folder_body'
+_U = '%Y%m%d_%H%M%S'
+_T = '用例'
+_S = 'log'
+_R = 'info error-info'
+_Q = '%Y-%m-%d %H:%M:%S'
+_P = 'utf8'
+_O = 'label'
+_N = 'suite'
+_M = 'class'
+_L = 'case_teardown_fail'
+_K = 'suite_teardown_fail'
+_J = 'case_setup_fail'
+_I = 'suite_setup_fail'
+_H = 'case_pass'
+_G = '\n'
+_F = 'Traceback:\n'
+_E = 'case_abort'
+_D = 'case_fail'
+_C = 'case_count'
+_B = 'bright_red'
+_A = None
+import logging, os, time
 from logging.handlers import RotatingFileHandler
 from rich.console import Console
 from rich.theme import Theme
 from hytest.product import version
 from datetime import datetime
 from hytest.common import GSTORE
-os.makedirs(_S,exist_ok=True)
-logger=logging.getLogger('my_logger')
+
+os.makedirs(_S, exist_ok=True)
+logger = logging.getLogger('my_logger')
 logger.setLevel(logging.DEBUG)
-logFile=os.path.join(_S,'testresult.log')
-handler=RotatingFileHandler(logFile,maxBytes=1024*1024*30,backupCount=2,encoding=_P)
+logFile = os.path.join(_S, 'testresult.log')
+handler = RotatingFileHandler(logFile, maxBytes=1024 * 1024 * 30, backupCount=2, encoding=_P)
 handler.setLevel(logging.DEBUG)
-formatter=logging.Formatter(fmt='%(message)s')
+formatter = logging.Formatter(fmt='%(message)s')
 handler.setFormatter(formatter)
 handler.doRollover()
 logger.addHandler(handler)
-console=Console(theme=Theme(inherit=False))
-print=console.print
-class LogLevel:level=0
+console = Console(theme=Theme(inherit=False))
+print = console.print
+
+
+class LogLevel: level = 0
+
+
 class Stats:
-	def testStart(self,_title='Test Report'):self.result={_C:0,_H:0,_D:0,_E:0,_I:0,_J:0,_K:0,_L:0,_a:[],_b:[],_c:[]};self.start_time=time.time()
-	def testEnd(self):
-		A='---ret---';self.end_time=time.time();self.test_duration=self.end_time-self.start_time
-		if self.result[_D]or self.result[_E]or self.result[_I]or self.result[_J]or self.result[_K]or self.result[_L]:GSTORE[A]=1
-		else:GSTORE[A]=0
-	def enter_case(self,caseId,name,case_className):self.result[_C]+=1
-	def case_pass(self,caseId,name):self.result[_H]+=1;self.result[_a].append(caseId)
-	def case_fail(self,caseId,name,e,stacktrace):self.result[_D]+=1;self.result[_b].append(caseId)
-	def case_abort(self,caseId,name,e,stacktrace):self.result[_E]+=1;self.result[_c].append(caseId)
-	def setup_fail(self,name,utype,e,stacktrace):
-		if utype==_N:self.result[_I]+=1
-		else:self.result[_J]+=1
-	def teardown_fail(self,name,utype,e,stacktrace):
-		if utype==_N:self.result[_K]+=1
-		else:self.result[_L]+=1
-stats=Stats()
+    def testStart(self, _title='Test Report'):
+        self.result = {_C: 0, _H: 0, _D: 0, _E: 0, _I: 0, _J: 0, _K: 0, _L: 0, _a: [], _b: [],
+                       _c: []};self.start_time = time.time()
+
+    def testEnd(self):
+        A = '---ret---';
+        self.end_time = time.time();
+        self.test_duration = self.end_time - self.start_time
+        if self.result[_D] or self.result[_E] or self.result[_I] or self.result[_J] or self.result[_K] or self.result[
+            _L]:
+            GSTORE[A] = 1
+        else:
+            GSTORE[A] = 0
+
+    def enter_case(self, caseId, name, case_className):
+        self.result[_C] += 1
+
+    def case_pass(self, caseId, name):
+        self.result[_H] += 1;self.result[_a].append(caseId)
+
+    def case_fail(self, caseId, name, e, stacktrace):
+        self.result[_D] += 1;self.result[_b].append(caseId)
+
+    def case_abort(self, caseId, name, e, stacktrace):
+        self.result[_E] += 1;self.result[_c].append(caseId)
+
+    def setup_fail(self, name, utype, e, stacktrace):
+        if utype == _N:
+            self.result[_I] += 1
+        else:
+            self.result[_J] += 1
+
+    def teardown_fail(self, name, utype, e, stacktrace):
+        if utype == _N:
+            self.result[_K] += 1
+        else:
+            self.result[_L] += 1
+
+
+stats = Stats()
+
+
 class ConsoleLogger:
-	def testEnd(self):A='white';ret=stats.result;print(f"\n\n  ========= 测试耗时 : {stats.test_duration:.3f} 秒 =========\n");print(f"\n  用例数量 : {ret[_C]}");print(f"\n  通过 : {ret[_H]}",style=_d);num=ret[_D];style=A if num==0 else _B;print(f"\n  失败 : {num}",style=style);num=ret[_E];style=A if num==0 else _B;print(f"\n  异常 : {num}",style=style);num=ret[_I];style=A if num==0 else _B;print(f"\n  套件初始化失败 : {num}",style=style);num=ret[_K];style=A if num==0 else _B;print(f"\n  套件清除  失败 : {num}",style=style);num=ret[_J];style=A if num==0 else _B;print(f"\n  用例初始化失败 : {num}",style=style);num=ret[_L];style=A if num==0 else _B;print(f"\n  用例清除  失败 : {num}",style=style)
-	def enter_suite(self,name,suitetype):
-		if suitetype=='file':print(f"\n\n>>> {name}",style='bold bright_black')
-	def enter_case(self,caseId,name,case_className):print(f"\n* {name}",style='bright_white')
-	def case_steps(self,name):...
-	def case_pass(self,caseId,name):print('                          PASS',style=_d)
-	def case_fail(self,caseId,name,e,stacktrace):print(f"                          FAIL\n{e}",style=_B)
-	def case_abort(self,caseId,name,e,stacktrace):print(f"                          ABORT\n{e}",style='magenta')
-	def case_check_point(self,msg):...
-	def setup(self,name,utype):...
-	def teardown(self,name,utype):...
-	def setup_fail(self,name,utype,e,stacktrace):utype='套件'if utype==_N else _T;print(f"\n{utype} 初始化失败 | {name} | {e}",style=_B)
-	def teardown_fail(self,name,utype,e,stacktrace):utype='套件'if utype==_N else _T;print(f"\n{utype} 清除失败 | {name} | {e}",style=_B)
-	def debug(self,msg):
-		if LogLevel.level>0:print(f"{msg}")
-	def criticalInfo(self,msg):print(f"{msg}",style=_B)
+    def testEnd(self):
+        A = 'white';ret = stats.result;print(f"\n\n  ========= 测试耗时 : {stats.test_duration:.3f} 秒 =========\n");print(
+            f"\n  用例数量 : {ret[_C]}");print(f"\n  通过 : {ret[_H]}", style=_d);num = ret[
+            _D];style = A if num == 0 else _B;print(f"\n  失败 : {num}", style=style);num = ret[
+            _E];style = A if num == 0 else _B;print(f"\n  异常 : {num}", style=style);num = ret[
+            _I];style = A if num == 0 else _B;print(f"\n  套件初始化失败 : {num}", style=style);num = ret[
+            _K];style = A if num == 0 else _B;print(f"\n  套件清除  失败 : {num}", style=style);num = ret[
+            _J];style = A if num == 0 else _B;print(f"\n  用例初始化失败 : {num}", style=style);num = ret[
+            _L];style = A if num == 0 else _B;print(f"\n  用例清除  失败 : {num}", style=style)
+
+    def enter_suite(self, name, suitetype):
+        if suitetype == 'file': print(f"\n\n>>> {name}", style='bold blue')
+
+    def enter_case(self, caseId, name, case_className):
+        print(f"\n* {name}", style='bright_white')
+
+    def case_steps(self, name):
+        ...
+
+    def case_pass(self, caseId, name):
+        print('                          PASS', style=_d)
+
+    def case_fail(self, caseId, name, e, stacktrace):
+        print(f"                          FAIL\n{e}", style=_B)
+
+    def case_abort(self, caseId, name, e, stacktrace):
+        print(f"                          ABORT\n{e}", style='magenta')
+
+    def case_check_point(self, msg):
+        ...
+
+    def setup(self, name, utype):
+        ...
+
+    def teardown(self, name, utype):
+        ...
+
+    def setup_fail(self, name, utype, e, stacktrace):
+        utype = '套件' if utype == _N else _T;print(f"\n{utype} 初始化失败 | {name} | {e}", style=_B)
+
+    def teardown_fail(self, name, utype, e, stacktrace):
+        utype = '套件' if utype == _N else _T;print(f"\n{utype} 清除失败 | {name} | {e}", style=_B)
+
+    def debug(self, msg):
+        if LogLevel.level > 0: print(f"{msg}")
+
+    def criticalInfo(self, msg):
+        print(f"{msg}", style=_B)
+
+
 class TextLogger:
-	def testStart(self,_title=''):startTime=time.strftime(_U,time.localtime(stats.start_time));logger.info(f"\n\n  ========= 测试开始 : {startTime} =========\n")
-	def testEnd(self):endTime=time.strftime(_U,time.localtime(stats.end_time));logger.info(f"\n\n  ========= 测试结束 : {endTime} =========\n");logger.info(f"\n  耗时    : {stats.end_time-stats.start_time:.3f} 秒\n");ret=stats.result;logger.info(f"\n  用例数量 : {ret[_C]}");logger.info(f"\n  通过 : {ret[_H]}");logger.info(f"\n  失败 : {ret[_D]}");logger.info(f"\n  异常 : {ret[_E]}");logger.info(f"\n  套件初始化失败 : {ret[_I]}");logger.info(f"\n  套件清除  失败 : {ret[_K]}");logger.info(f"\n  用例初始化失败 : {ret[_J]}");logger.info(f"\n  用例清除  失败 : {ret[_L]}")
-	def enter_suite(self,name,suitetype):logger.info(f"\n\n>>> {name}")
-	def enter_case(self,caseId,name,case_className):curTime=datetime.now().strftime(_Q);logger.info(f"\n* {name}  -  {curTime}")
-	def case_steps(self,name):logger.info(f"\n  [ case execution steps ]")
-	def case_pass(self,caseId,name):logger.info('  PASS ')
-	def case_fail(self,caseId,name,e,stacktrace):stacktrace=_F+stacktrace.split(_G,3)[3];logger.info(f"  FAIL   {e} \n{stacktrace}")
-	def case_abort(self,caseId,name,e,stacktrace):stacktrace=_F+stacktrace.split(_G,3)[3];logger.info(f"  ABORT   {e} \n{stacktrace}")
-	def case_check_point(self,msg):logger.info(f"\n-- check {msg}")
-	def setup(self,name,utype):logger.info(f"\n[ {utype} setup ] {name}")
-	def teardown(self,name,utype):logger.info(f"\n[ {utype} teardown ] {name}")
-	def setup_fail(self,name,utype,e,stacktrace):stacktrace=_F+stacktrace.split(_G,3)[3];logger.info(f"{utype} setup fail | {e} \n{stacktrace}")
-	def teardown_fail(self,name,utype,e,stacktrace):stacktrace=_F+stacktrace.split(_G,3)[3];logger.info(f"{utype} teardown fail | {e} \n{stacktrace}")
-	def info(self,msg):logger.info(msg)
-	def debug(self,msg):
-		if LogLevel.level>0:logger.debug(msg)
-	def step(self,stepNo,desc):logger.info(f"\n-- 第 {stepNo} 步 -- {desc} \n")
-	def checkpoint_pass(self,desc):logger.info(f"\n** 检查点 **  {desc} ---->  通过\n")
-	def checkpoint_fail(self,desc):logger.info(f"\n** 检查点 **  {desc} ---->  !! 不通过!!\n")
-	def criticalInfo(self,msg):logger.info(f"!!! {msg} !!!")
-	def log_img(self,imgPath,width=_A):logger.info(f"图 {imgPath}")
+    def testStart(self, _title=''): startTime = time.strftime(_U, time.localtime(stats.start_time));logger.info(
+        f"\n\n  ========= 测试开始 : {startTime} =========\n")
+
+    def testEnd(self): endTime = time.strftime(_U, time.localtime(stats.end_time));logger.info(
+        f"\n\n  ========= 测试结束 : {endTime} =========\n");logger.info(
+        f"\n  耗时    : {stats.end_time - stats.start_time:.3f} 秒\n");ret = stats.result;logger.info(
+        f"\n  用例数量 : {ret[_C]}");logger.info(f"\n  通过 : {ret[_H]}");logger.info(f"\n  失败 : {ret[_D]}");logger.info(
+        f"\n  异常 : {ret[_E]}");logger.info(f"\n  套件初始化失败 : {ret[_I]}");logger.info(
+        f"\n  套件清除  失败 : {ret[_K]}");logger.info(f"\n  用例初始化失败 : {ret[_J]}");logger.info(f"\n  用例清除  失败 : {ret[_L]}")
+
+    def enter_suite(self, name, suitetype): logger.info(f"\n\n>>> {name}")
+
+    def enter_case(self, caseId, name, case_className): curTime = datetime.now().strftime(_Q);logger.info(
+        f"\n* {name}  -  {curTime}")
+
+    def case_steps(self, name): logger.info(f"\n  [ case execution steps ]")
+
+    def case_pass(self, caseId, name): logger.info('  PASS ')
+
+    def case_fail(self, caseId, name, e, stacktrace): stacktrace = _F + stacktrace.split(_G, 3)[3];logger.info(
+        f"  FAIL   {e} \n{stacktrace}")
+
+    def case_abort(self, caseId, name, e, stacktrace): stacktrace = _F + stacktrace.split(_G, 3)[3];logger.info(
+        f"  ABORT   {e} \n{stacktrace}")
+
+    def case_check_point(self, msg): logger.info(f"\n-- check {msg}")
+
+    def setup(self, name, utype): logger.info(f"\n[ {utype} setup ] {name}")
+
+    def teardown(self, name, utype): logger.info(f"\n[ {utype} teardown ] {name}")
+
+    def setup_fail(self, name, utype, e, stacktrace): stacktrace = _F + stacktrace.split(_G, 3)[3];logger.info(
+        f"{utype} setup fail | {e} \n{stacktrace}")
+
+    def teardown_fail(self, name, utype, e, stacktrace): stacktrace = _F + stacktrace.split(_G, 3)[3];logger.info(
+        f"{utype} teardown fail | {e} \n{stacktrace}")
+
+    def info(self, msg): logger.info(msg)
+
+    def debug(self, msg):
+        if LogLevel.level > 0: logger.debug(msg)
+
+    def step(self, stepNo, desc): logger.info(f"\n-- 第 {stepNo} 步 -- {desc} \n")
+
+    def checkpoint_pass(self, desc): logger.info(f"\n** 检查点 **  {desc} ---->  通过\n")
+
+    def checkpoint_fail(self, desc): logger.info(f"\n** 检查点 **  {desc} ---->  !! 不通过!!\n")
+
+    def criticalInfo(self, msg): logger.info(f"!!! {msg} !!!")
+
+    def log_img(self, imgPath, width=_A): logger.info(f"图 {imgPath}")
+
+
 from dominate.tags import *
 from dominate.util import raw
 from dominate import document
+
+
 class HtmlLogger:
-	def __init__(self):self.curEle=_A
-	def testStart(self,_title=''):
-		A='menu-item'
-		with open(os.path.join(os.path.dirname(__file__),'report.css'),encoding=_P)as f:_css_style=f.read()
-		with open(os.path.join(os.path.dirname(__file__),'report.js'),encoding=_P)as f:_js=f.read()
-		self.doc=document(title=f"测试报告");self.doc.head.add(meta(charset='UTF-8'),style(raw(_css_style)),script(raw(_js),type='text/javascript'));self.main=self.doc.body.add(div(_class='main_section'));self.main.add(h1(f"测试报告 - hytest v{version}",style='font-family: auto'));self.main.add(h3(f"统计结果"));resultDiv=self.main.add(div(_class='result'));self.result_table,self.result_barchart=resultDiv.add(table(_class='result_table'),div(_class='result_barchart'));_,self.logDiv=self.main.add(div(h3('执行日志',style='display:inline'),style='margin-top:2em'),div(_class='exec_log'));self.ev=div(div('∧',_class=A,onclick='previous_error()',title='上一个错误'),div('∨',_class=A,onclick='next_error()',title='下一个错误'),_class='error_jumper');self.main.add(div(div('页首',_class=A,onclick='document.querySelector("body").scrollIntoView()'),div('教程',_class=A,onclick='window.open("http://www.byhy.net/tut/auto/hytest/01", "_blank"); '),div('精简',_class=A,id='display_mode',onclick='toggle_folder_all_cases()'),self.ev,id='float_menu'));self.curEle=self.main;self.curSuiteEle=_A;self.curCaseEle=_A;self.curCaseLableEle=_A;self.curSetupEle=_A;self.curTeardownEle=_A;self.suitepath2element={}
-	def testEnd(self):
-		B='%Y%m%d %H:%M:%S';A='color:red';execStartTime=time.strftime(B,time.localtime(stats.start_time));execEndTime=time.strftime(B,time.localtime(stats.end_time));ret=stats.result;errorNum=0;trs=[];trs.append(tr(td('开始时间'),td(f"{execStartTime}")));trs.append(tr(td('结束时间'),td(f"{execEndTime}")));trs.append(tr(td('耗时'),td(f"{stats.test_duration:.3f} 秒")));trs.append(tr(td('用例数量'),td(f"{ret[_C]}")));trs.append(tr(td('通过'),td(f"{ret[_H]}")));num=ret[_D];style=''if num==0 else A;trs.append(tr(td('失败'),td(f"{num}",style=style)));errorNum+=num;num=ret[_E];style=''if num==0 else A;trs.append(tr(td('异常'),td(f"{num}",style=style)));errorNum+=num;num=ret[_I];style=''if num==0 else A;trs.append(tr(td('套件初始化失败'),td(f"{num}",style=style)));errorNum+=num;num=ret[_K];style=''if num==0 else A;trs.append(tr(td('套件清除失败'),td(f"{num}",style=style)));errorNum+=num;num=ret[_J];style=''if num==0 else A;trs.append(tr(td('用例初始化失败'),td(f"{num}",style=style)));errorNum+=num;num=ret[_L];style=''if num==0 else A;trs.append(tr(td('用例清除失败'),td(f"{num}",style=style)));errorNum+=num;self.ev['display']='none'if errorNum==0 else'block';self.result_table.add(tbody(*trs))
-		def add_barchar_item(statName,percent,color):
-			if type(percent)==str:barPercentStr=percent;percentStr='-'
-			else:barPercent=1 if 0<percent<=1 else percent;barPercentStr=f"{barPercent}%";percentStr=f"{percent}%"
-			self.result_barchart.add(div(span(statName),div(div(percentStr,style=f"width: {barPercentStr}; background-color: {color};",_class='barchart_bar'),_class='barchart_barbox'),_class='barchar_item'))
-		pass_percent=round(ret[_H]*100/ret[_C],2);percent=0 if pass_percent==0 else pass_percent;add_barchar_item(f"用例通过 {percent}% ： {ret[_H]} 个",percent,'#04AA6D');fail_percent=round(ret[_D]*100/ret[_C],2);percent=0 if fail_percent==0 else fail_percent;add_barchar_item(f"用例失败 {percent}% ： {ret[_D]} 个",percent,'#bb4069');abort_percent=round(ret[_E]*100/ret[_C],2);percent=0 if abort_percent==0 else abort_percent;add_barchar_item(f"用例异常 {percent}% ： {ret[_E]} 个",percent,'#9c27b0');st_fail=ret[_I]+ret[_J]+ret[_K]+ret[_L];percent='100%'if st_fail>0 else'0%';add_barchar_item(f"初始化/清除 失败  {st_fail} 次",percent,'#dcbdbd');htmlcontent=self.doc.render();timestamp=time.strftime(_U,time.localtime(stats.start_time));reportFile=os.path.join(_S,f"log_{timestamp}.html")
-		with open(reportFile,'w',encoding=_P)as f:f.write(htmlcontent)
-		try:os.startfile(reportFile)
-		except:
-			try:os.system(f"open {reportFile}")
-			except:...
-	def enter_suite(self,name,suitetype):_class='suite_'+suitetype;enterInfo='进入目录'if suitetype=='dir'else'进入文件';self.curEle=self.logDiv.add(div(div(span(enterInfo,_class=_O),span(name)),_class=_class,id=f"{_class} {name}"));self.curSuiteEle=self.curEle;self.curSuiteFilePath=name;self.suitepath2element[name]=self.curEle
-	def enter_case(self,caseId,name,case_className):self.curCaseLableEle=span(_T,_class='label caselabel');self.curCaseBodyEle=div(span(f"{self.curSuiteFilePath}::{case_className}",_class='case_class_path'),_class=_V);self.curCaseEle=self.curSuiteEle.add(div(div(self.curCaseLableEle,span(name,_class='casename'),span(datetime.now().strftime(_Q),_class=_W),_class=_X),self.curCaseBodyEle,_class='case',id=f"case_{caseId:08}"));self.curEle=self.curCaseBodyEle
-	def case_steps(self,name):ele=div(span('测试步骤',_class=_O),_class='test_steps',id='test_steps '+name);self.curEle=self.curCaseBodyEle.add(ele)
-	def case_pass(self,caseId,name):self.curCaseEle[_M]+=' pass';self.curCaseLableEle+=' PASS'
-	def case_fail(self,caseId,name,e,stacktrace):self.curCaseEle[_M]+=_Y;self.curCaseLableEle+=' FAIL';stacktrace=_F+stacktrace.split(_G,3)[3];self.curEle+=div(f"{e} \n{stacktrace}",_class=_R)
-	def case_abort(self,caseId,name,e,stacktrace):self.curCaseEle[_M]+=' abort';self.curCaseLableEle+=' ABORT';stacktrace=_F+stacktrace.split(_G,3)[3];self.curEle+=div(f"{e} \n{stacktrace}",_class=_R)
-	def case_check_point(self,msg):0
-	def setup(self,name,utype):
-		_class=f"{utype}_setup setup"
-		if utype==_N:stHeaderEle=div(span('套件初始化',_class=_O),span(name),span(datetime.now().strftime(_Q),_class=_W),_class=_X);stBodyEle=self.curEle=div(_class=_V);self.curSetupEle=div(stHeaderEle,stBodyEle,_class=_class,id=f"{_class} {name}");self.curSuiteEle.add(self.curSetupEle)
-		else:self.curSetupEle=self.curEle=div(span('用例初始化',_class=_O),_class=_class,id=f"{_class} {name}");self.curCaseBodyEle.add(self.curSetupEle);self.curEle[_M]+=_e
-	def teardown(self,name,utype):
-		_class=f"{utype}_teardown teardown"
-		if utype==_N:stHeaderEle=div(span('套件清除',_class=_O),span(name),span(datetime.now().strftime(_Q),_class=_W),_class=_X);stBodyEle=self.curEle=div(_class=_V);self.curTeardownEle=div(stHeaderEle,stBodyEle,_class=_class,id=f"{_class} {name}");self.curSuiteEle.add(self.curTeardownEle)
-		else:self.curTeardownEle=self.curEle=div(span('用例清除',_class=_O),_class=_class,id=f"{_class} {name}");self.curCaseBodyEle.add(self.curTeardownEle);self.curEle[_M]+=_e
-	def setup_fail(self,name,utype,e,stacktrace):self.curSetupEle[_M]+=_Y;stacktrace=_F+stacktrace.split(_G,3)[3];self.curEle+=div(f"{utype} setup fail | {e} \n{stacktrace}",_class=_R)
-	def teardown_fail(self,name,utype,e,stacktrace):self.curTeardownEle[_M]+=_Y;stacktrace=_F+stacktrace.split(_G,3)[3];self.curEle+=div(f"{utype} teardown fail | {e} \n{stacktrace}",_class=_R)
-	def info(self,msg):
-		if self.curEle is _A:return
-		self.curEle+=div(msg,_class='info')
-	def step(self,stepNo,desc):
-		if self.curEle is _A:return
-		self.curEle+=div(span(f"第 {stepNo} 步",_class=_Z),span(desc),_class='case_step')
-	def checkpoint_pass(self,desc):
-		if self.curEle is _A:return
-		self.curEle+=div(span(f"检查点 PASS",_class=_Z),span(desc),_class='checkpoint_pass')
-	def checkpoint_fail(self,desc):
-		if self.curEle is _A:return
-		self.curEle+=div(span(f"检查点 FAIL",_class=_Z),span(desc),_class='checkpoint_fail')
-	def log_img(self,imgPath,width=_A):
-		if self.curEle is _A:return
-		self.curEle+=div(img(src=imgPath,width='aa'if width is _A else width,_class='screenshot'))
+    def __init__(self):
+        self.curEle = _A
+
+    def testStart(self, _title=''):
+        A = 'menu-item'
+        with open(os.path.join(os.path.dirname(__file__), 'report.css'), encoding=_P)as f: _css_style = f.read()
+        with open(os.path.join(os.path.dirname(__file__), 'report.js'), encoding=_P)as f: _js = f.read()
+        self.doc = document(title=f"测试报告");
+        self.doc.head.add(meta(charset='UTF-8'), style(raw(_css_style)), script(raw(_js), type='text/javascript'));
+        self.main = self.doc.body.add(div(_class='main_section'));
+        self.main.add(h1(f"测试报告 - hytest v{version}", style='font-family: auto'));
+        self.main.add(h3(f"统计结果"));
+        resultDiv = self.main.add(div(_class='result'));
+        self.result_table, self.result_barchart = resultDiv.add(table(_class='result_table'),
+                                                                div(_class='result_barchart'));
+        _, self.logDiv = self.main.add(div(h3('执行日志', style='display:inline'), style='margin-top:2em'),
+                                       div(_class='exec_log'));
+        self.ev = div(div('∧', _class=A, onclick='previous_error()', title='上一个错误'),
+                      div('∨', _class=A, onclick='next_error()', title='下一个错误'), _class='error_jumper');
+        self.main.add(div(div('页首', _class=A, onclick='document.querySelector("body").scrollIntoView()'),
+                          div('教程', _class=A,
+                              onclick='window.open("http://www.byhy.net/tut/auto/hytest/01", "_blank"); '),
+                          div('精简', _class=A, id='display_mode', onclick='toggle_folder_all_cases()'), self.ev,
+                          id='float_menu'));
+        self.curEle = self.main;
+        self.curSuiteEle = _A;
+        self.curCaseEle = _A;
+        self.curCaseLableEle = _A;
+        self.curSetupEle = _A;
+        self.curTeardownEle = _A;
+        self.suitepath2element = {}
+
+    def testEnd(self):
+        B = '%Y%m%d %H:%M:%S';
+        A = 'color:red';
+        execStartTime = time.strftime(B, time.localtime(stats.start_time));
+        execEndTime = time.strftime(B, time.localtime(stats.end_time));
+        ret = stats.result;
+        errorNum = 0;
+        trs = [];
+        trs.append(tr(td('开始时间'), td(f"{execStartTime}")));
+        trs.append(tr(td('结束时间'), td(f"{execEndTime}")));
+        trs.append(tr(td('耗时'), td(f"{stats.test_duration:.3f} 秒")));
+        trs.append(tr(td('用例数量'), td(f"{ret[_C]}")));
+        trs.append(tr(td('通过'), td(f"{ret[_H]}")));
+        num = ret[_D];
+        style = '' if num == 0 else A;
+        trs.append(tr(td('失败'), td(f"{num}", style=style)));
+        errorNum += num;
+        num = ret[_E];
+        style = '' if num == 0 else A;
+        trs.append(tr(td('异常'), td(f"{num}", style=style)));
+        errorNum += num;
+        num = ret[_I];
+        style = '' if num == 0 else A;
+        trs.append(tr(td('套件初始化失败'), td(f"{num}", style=style)));
+        errorNum += num;
+        num = ret[_K];
+        style = '' if num == 0 else A;
+        trs.append(tr(td('套件清除失败'), td(f"{num}", style=style)));
+        errorNum += num;
+        num = ret[_J];
+        style = '' if num == 0 else A;
+        trs.append(tr(td('用例初始化失败'), td(f"{num}", style=style)));
+        errorNum += num;
+        num = ret[_L];
+        style = '' if num == 0 else A;
+        trs.append(tr(td('用例清除失败'), td(f"{num}", style=style)));
+        errorNum += num;
+        self.ev['display'] = 'none' if errorNum == 0 else 'block';
+        self.result_table.add(tbody(*trs))
+
+        def add_barchar_item(statName, percent, color):
+            if type(percent) == str:
+                barPercentStr = percent;percentStr = '-'
+            else:
+                barPercent = 1 if 0 < percent <= 1 else percent;barPercentStr = f"{barPercent}%";percentStr = f"{percent}% "
+            self.result_barchart.add(div(span(statName), div(
+                div(percentStr, style=f"width: {barPercentStr}; background-color: {color};", _class='barchart_bar'),
+                _class='barchart_barbox'), _class='barchar_item'))
+
+        pass_percent = round(ret[_H] * 100 / ret[_C], 2);
+        percent = 0 if pass_percent == 0 else pass_percent;
+        add_barchar_item(f"用例通过 {percent}% ： {ret[_H]} 个", percent, '#04AA6D');
+        fail_percent = round(ret[_D] * 100 / ret[_C], 2);
+        percent = 0 if fail_percent == 0 else fail_percent;
+        add_barchar_item(f"用例失败 {percent}% ： {ret[_D]} 个", percent, '#bb4069');
+        abort_percent = round(ret[_E] * 100 / ret[_C], 2);
+        percent = 0 if abort_percent == 0 else abort_percent;
+        add_barchar_item(f"用例异常 {percent}% ： {ret[_E]} 个", percent, '#9c27b0');
+        st_fail = ret[_I] + ret[_J] + ret[_K] + ret[_L];
+        percent = '100%' if st_fail > 0 else '0%';
+        add_barchar_item(f"初始化/清除 失败  {st_fail} 次", percent, '#dcbdbd');
+        htmlcontent = self.doc.render();
+        timestamp = time.strftime(_U, time.localtime(stats.start_time));
+        reportFile = os.path.join(_S, f"log_{timestamp}.html")
+        with open(reportFile, 'w', encoding=_P)as f:
+            f.write(htmlcontent)
+        try:
+            os.startfile(reportFile)
+        except:
+            try:
+                os.system(f"open {reportFile}")
+            except:
+                ...
+
+    def enter_suite(self, name, suitetype):
+        _class = 'suite_' + suitetype;enterInfo = '进入目录' if suitetype == 'dir' else '进入文件';self.curEle = self.logDiv.add(
+            div(div(span(enterInfo, _class=_O), span(name)), _class=_class,
+                id=f"{_class} {name}"));self.curSuiteEle = self.curEle;self.curSuiteFilePath = name;
+        self.suitepath2element[name] = self.curEle
+
+    def enter_case(self, caseId, name, case_className):
+        self.curCaseLableEle = span(_T, _class='label caselabel');self.curCaseBodyEle = div(
+            span(f"{self.curSuiteFilePath}::{case_className}", _class='case_class_path'),
+            _class=_V);self.curCaseEle = self.curSuiteEle.add(div(
+            div(self.curCaseLableEle, span(name, _class='casename'), span(datetime.now().strftime(_Q), _class=_W),
+                _class=_X), self.curCaseBodyEle, _class='case',
+            id=f"case_{caseId:08}"));self.curEle = self.curCaseBodyEle
+
+    def case_steps(self, name):
+        ele = div(span('测试步骤', _class=_O), _class='test_steps',
+                  id='test_steps ' + name);self.curEle = self.curCaseBodyEle.add(ele)
+
+    def case_pass(self, caseId, name):
+        self.curCaseEle[_M] += ' pass';self.curCaseLableEle += ' PASS'
+
+    def case_fail(self, caseId, name, e, stacktrace):
+        self.curCaseEle[_M] += _Y;self.curCaseLableEle += ' FAIL';stacktrace = _F + stacktrace.split(_G, 3)[
+            3];self.curEle += div(f"{e} \n{stacktrace}", _class=_R)
+
+    def case_abort(self, caseId, name, e, stacktrace):
+        self.curCaseEle[_M] += ' abort';self.curCaseLableEle += ' ABORT';stacktrace = _F + stacktrace.split(_G, 3)[
+            3];self.curEle += div(f"{e} \n{stacktrace}", _class=_R)
+
+    def case_check_point(self, msg):
+        0
+
+    def setup(self, name, utype):
+        _class = f"{utype}_setup setup"
+        if utype == _N:
+            stHeaderEle = div(span('套件初始化', _class=_O), span(name), span(datetime.now().strftime(_Q), _class=_W),
+                              _class=_X);stBodyEle = self.curEle = div(_class=_V);self.curSetupEle = div(stHeaderEle,
+                                                                                                         stBodyEle,
+                                                                                                         _class=_class,
+                                                                                                         id=f"{_class} {name}");self.curSuiteEle.add(
+                self.curSetupEle)
+        else:
+            self.curSetupEle = self.curEle = div(span('用例初始化', _class=_O), _class=_class,
+                                                 id=f"{_class} {name}");self.curCaseBodyEle.add(self.curSetupEle);
+            self.curEle[_M] += _e
+
+    def teardown(self, name, utype):
+        _class = f"{utype}_teardown teardown"
+        if utype == _N:
+            stHeaderEle = div(span('套件清除', _class=_O), span(name), span(datetime.now().strftime(_Q), _class=_W),
+                              _class=_X);stBodyEle = self.curEle = div(_class=_V);self.curTeardownEle = div(stHeaderEle,
+                                                                                                            stBodyEle,
+                                                                                                            _class=_class,
+                                                                                                            id=f"{_class} {name}");self.curSuiteEle.add(
+                self.curTeardownEle)
+        else:
+            self.curTeardownEle = self.curEle = div(span('用例清除', _class=_O), _class=_class,
+                                                    id=f"{_class} {name}");self.curCaseBodyEle.add(self.curTeardownEle);
+            self.curEle[_M] += _e
+
+    def setup_fail(self, name, utype, e, stacktrace):
+        self.curSetupEle[_M] += _Y;stacktrace = _F + stacktrace.split(_G, 3)[3];self.curEle += div(
+            f"{utype} setup fail | {e} \n{stacktrace}", _class=_R)
+
+    def teardown_fail(self, name, utype, e, stacktrace):
+        self.curTeardownEle[_M] += _Y;stacktrace = _F + stacktrace.split(_G, 3)[3];self.curEle += div(
+            f"{utype} teardown fail | {e} \n{stacktrace}", _class=_R)
+
+    def info(self, msg):
+        if self.curEle is _A: return
+        self.curEle += div(msg, _class='info')
+
+    def step(self, stepNo, desc):
+        if self.curEle is _A: return
+        self.curEle += div(span(f"第 {stepNo} 步", _class=_Z), span(desc), _class='case_step')
+
+    def checkpoint_pass(self, desc):
+        if self.curEle is _A: return
+        self.curEle += div(span(f"检查点 PASS", _class=_Z), span(desc), _class='checkpoint_pass')
+
+    def checkpoint_fail(self, desc):
+        if self.curEle is _A: return
+        self.curEle += div(span(f"检查点 FAIL", _class=_Z), span(desc), _class='checkpoint_fail')
+
+    def log_img(self, imgPath, width=_A):
+        if self.curEle is _A: return
+        self.curEle += div(img(src=imgPath, width='aa' if width is _A else width, _class='screenshot'))
+
+
 from .signal import signal
-signal.register([stats,ConsoleLogger(),TextLogger(),HtmlLogger()])
+
+signal.register([stats, ConsoleLogger(), TextLogger(), HtmlLogger()])

--- a/src/utils/runner.py
+++ b/src/utils/runner.py
@@ -78,16 +78,22 @@ class Collector:
 					else:
 						cls_ddt_cases = module.__dict__['cls_ddt_cases']
 						for cls_data in cls_ddt_cases:
-							case = item()
-							case.cls_para = cls_data['cls_para']
 							if hasattr(item, _K) and not hasattr(item, 'ddt_cases'):
+								case = item()
+								case.cls_para = cls_data['cls_para']
 								case.name = f"{cls_data['cls_name']}-{case.name}"
 								meta[_A].append(case)
 							elif hasattr(item, 'ddt_cases'):
 								for caseData in item.ddt_cases:
+									case = item()
+									case.cls_para = cls_data['cls_para']
 									case.name, case.para = f"{cls_data['cls_name']}-{caseData[_K]}", caseData['para'];
 									meta[_A].append(case)
+									if '032' in caseData[_K] or '033' in caseData[_K]:
+										print(case)
 							else:
+								case = item()
+								case.cls_para = cls_data['cls_para']
 								case.name = f"{cls_data['cls_name']}-{name}"
 								meta[_A].append(case)
 		new_suite_tag_table={}

--- a/src/utils/runner.py
+++ b/src/utils/runner.py
@@ -1,209 +1,280 @@
-_Q='casefile'
-_P='.py'
-_O='test_teardown'
-_N='test_setup'
-_M='default_tags'
-_L='--teardown--'
-_K='name'
-_J='st'
-_I='suite_setup'
-_H='force_tags'
-_G='type'
-_F=None
-_E='suite_teardown'
-_D='__st__.py'
-_C=False
-_B=True
-_A='cases'
-import os,types,importlib.util,fnmatch,traceback
+_Q = 'casefile'
+_P = '.py'
+_O = 'test_teardown'
+_N = 'test_setup'
+_M = 'default_tags'
+_L = '--teardown--'
+_K = 'name'
+_J = 'st'
+_I = 'suite_setup'
+_H = 'force_tags'
+_G = 'type'
+_F = None
+_E = 'suite_teardown'
+_D = '__st__.py'
+_C = False
+_B = True
+_A = 'cases'
+import os, types, importlib.util, fnmatch, traceback
 from .signal import signal
+
+
 def tagmatch(pattern):
-	for tag in Collector.current_case_tags:
-		if fnmatch.fnmatch(tag,pattern):return _B
-	return _C
+    for tag in Collector.current_case_tags:
+        if fnmatch.fnmatch(tag, pattern): return _B
+    return _C
+
+
 class Collector:
-	SUITE_TAGS=[_H,_M];SUITE_STS=[_I,_E,_N,_O];exec_list=[];exec_table={};suite_tag_table={_H:{},_M:{}};current_case_tags=[]
-	@classmethod
-	def run(cls,casedir=_A,suitename_filters=[],casename_filters=[],tag_include_expr=_F,tag_exclude_expr=_F):
-		for (dirpath,dirnames,filenames) in os.walk(casedir):
-			if _D in filenames:filenames.remove(_D);filenames.insert(0,_D)
-			for fn in filenames:
-				filepath=os.path.join(dirpath,fn)
-				if not filepath.endswith(_P):continue
-				signal.debug(f"\n=== {filepath} \n");module_name=fn[:-3];spec=importlib.util.spec_from_file_location(module_name,filepath);module=importlib.util.module_from_spec(spec);spec.loader.exec_module(module);cls.handleOneModule(module,filepath,tag_include_expr,tag_exclude_expr,suitename_filters,casename_filters)
-		sts,cases=[],[]
-		for filepath in cls.exec_list:
-			if filepath.endswith('py'):cases.append(filepath)
-			else:sts.append(filepath)
-		for stPath in sts:
-			valid=_C
-			for casePath in cases:
-				if casePath.startswith(stPath):valid=_B;break
-			if not valid:cls.exec_list.remove(stPath);cls.exec_table.pop(stPath)
-	@classmethod
-	def handleOneModule(cls,module,filepath,tag_include_expr,tag_exclude_expr,suitename_filters,casename_filters):
-		stType=filepath.endswith(_D);caseType=not stType
-		if stType:filepath=filepath.replace(_D,'')
-		meta={_G:_Q if caseType else _J}
-		if caseType:meta[_A]=[]
-		cls_ddt = 'cls_ddt_cases' in module.__dict__.keys()
-		for (name,item) in module.__dict__.items():
-			if isinstance(item,list):
-				if name in cls.SUITE_TAGS:
-					if not item:continue
-					meta[name]=item;cls.suite_tag_table[name][filepath]=item
-			elif isinstance(item,types.FunctionType):
-				if name in cls.SUITE_STS:meta[name]=item
-			for (name, item) in module.__dict__.items():
-				if isinstance(item, list):
-					if name in cls.SUITE_TAGS:
-						if not item: continue
-						meta[name] = item;
-						cls.suite_tag_table[name][filepath] = item
-				elif isinstance(item, types.FunctionType):
-					if name in cls.SUITE_STS: meta[name] = item
-				elif caseType and isinstance(item, type):
-					if not hasattr(item, 'teststeps'): signal.debug(f"no teststeps in class {name}, skip it.");continue
-					if not cls_ddt:
-						if hasattr(item, _K) and not hasattr(item, 'ddt_cases'):
-							meta[_A].append(item())
-						elif hasattr(item, 'ddt_cases'):
-							for caseData in item.ddt_cases:
-								case = item();
-								case.name, case.para = caseData[_K], caseData['para'];
-								meta[_A].append(case)
-						else:
-							item.name = name;
-							meta[_A].append(item())
-					else:
-						cls_ddt_cases = module.__dict__['cls_ddt_cases']
-						for cls_data in cls_ddt_cases:
-							if hasattr(item, _K) and not hasattr(item, 'ddt_cases'):
-								case = item()
-								case.cls_para = cls_data['cls_para']
-								case.name = f"{cls_data['cls_name']}-{case.name}"
-								meta[_A].append(case)
-							elif hasattr(item, 'ddt_cases'):
-								for caseData in item.ddt_cases:
-									case = item()
-									case.cls_para = cls_data['cls_para']
-									case.name, case.para = f"{cls_data['cls_name']}-{caseData[_K]}", caseData['para'];
-									meta[_A].append(case)
-									if '032' in caseData[_K] or '033' in caseData[_K]:
-										print(case)
-							else:
-								case = item()
-								case.cls_para = cls_data['cls_para']
-								case.name = f"{cls_data['cls_name']}-{name}"
-								meta[_A].append(case)
-		new_suite_tag_table={}
-		for (tname,table) in cls.suite_tag_table.items():new_suite_tag_table[tname]={p:v for(p,v)in table.items()if filepath.startswith(p)}
-		cls.suite_tag_table=new_suite_tag_table
-		if caseType:
-			if not meta[_A]:signal.debug(f"\n--- finally, no cases in this module , skip it.");return
-			cls.caseFilter(filepath,meta,tag_include_expr,tag_exclude_expr,suitename_filters,casename_filters)
-			if not meta[_A]:signal.debug(f"\n--- finally, no cases in this module , skip it.");return
-		elif len(meta)==1:signal.debug(f"\n--- finally, no setup/teardown/tags in this module , skip it.");return
-		cls.exec_list.append(filepath);cls.exec_table[filepath]=meta
-	@classmethod
-	def caseFilter(cls,filepath,meta,tag_include_expr,tag_exclude_expr,suitename_filters,casename_filters):
-		if not tag_include_expr and not tag_exclude_expr and not suitename_filters and not casename_filters:return
-		if not tag_exclude_expr and suitename_filters:
-			suitenames=filepath.split(os.path.sep);suitenames=[sn[:-3]if sn.endswith(_P)else sn for sn in suitenames]
-			if cls._patternMatch(suitenames,suitename_filters):return
-		passedCases=[]
-		for caseClass in meta[_A]:
-			signal.debug(f"\n* {caseClass.name}");suite_tags=[t for tl in cls.suite_tag_table[_H].values()for t in tl];case_tags=getattr(caseClass,'tags',[]);cls.current_case_tags=set(suite_tags+case_tags)
-			if tag_exclude_expr:
-				if eval(tag_exclude_expr)==_B:signal.debug(f"excluded for meeting expr : {tag_exclude_expr}");continue
-				elif not casename_filters and not suitename_filters and not tag_include_expr:passedCases.append(caseClass);continue
-			if casename_filters:
-				caseName=getattr(caseClass,_K)
-				if cls._patternMatch([caseName],casename_filters):passedCases.append(caseClass);continue
-			if tag_include_expr:
-				if eval(tag_include_expr)==_B:passedCases.append(caseClass);continue
-			signal.debug(f"excluded for not meet any include rules")
-		meta[_A]=passedCases
-	@classmethod
-	def _patternMatch(cls,names,patterns):
-		for name in names:
-			for pattern in patterns:
-				if fnmatch.fnmatch(name,pattern):return _B
-		return _C
+    SUITE_TAGS = [_H, _M];
+    SUITE_STS = [_I, _E, _N, _O];
+    exec_list = [];
+    exec_table = {};
+    suite_tag_table = {_H: {}, _M: {}};
+    current_case_tags = []
+
+    @classmethod
+    def run(cls, casedir=_A, suitename_filters=[], casename_filters=[], tag_include_expr=_F, tag_exclude_expr=_F):
+        for (dirpath, dirnames, filenames) in os.walk(casedir):
+            if _D in filenames: filenames.remove(_D);filenames.insert(0, _D)
+            for fn in filenames:
+                filepath = os.path.join(dirpath, fn)
+                if not filepath.endswith(_P): continue
+                signal.debug(f"\n=== {filepath} \n");
+                module_name = fn[:-3];
+                spec = importlib.util.spec_from_file_location(module_name, filepath);
+                module = importlib.util.module_from_spec(spec);
+                spec.loader.exec_module(module);
+                cls.handleOneModule(module, filepath, tag_include_expr, tag_exclude_expr, suitename_filters,
+                                    casename_filters)
+        sts, cases = [], []
+        for filepath in cls.exec_list:
+            if filepath.endswith('py'):
+                cases.append(filepath)
+            else:
+                sts.append(filepath)
+        for stPath in sts:
+            valid = _C
+            for casePath in cases:
+                if casePath.startswith(stPath): valid = _B;break
+            if not valid: cls.exec_list.remove(stPath);cls.exec_table.pop(stPath)
+
+    @classmethod
+    def handleOneModule(cls, module, filepath, tag_include_expr, tag_exclude_expr, suitename_filters, casename_filters):
+        stType = filepath.endswith(_D);
+        caseType = not stType
+        if stType: filepath = filepath.replace(_D, '')
+        meta = {_G: _Q if caseType else _J}
+        if caseType: meta[_A] = []
+        cls_ddt = 'cls_ddt_cases' in module.__dict__.keys()
+        for (name, item) in module.__dict__.items():
+            if isinstance(item, list):
+                if name in cls.SUITE_TAGS:
+                    if not item: continue
+                    meta[name] = item;
+                    cls.suite_tag_table[name][filepath] = item
+            elif isinstance(item, types.FunctionType):
+                if name in cls.SUITE_STS: meta[name] = item
+            elif caseType and isinstance(item, type):
+                if not hasattr(item, 'teststeps'): signal.debug(f"no teststeps in class {name}, skip it.");continue
+                if not cls_ddt:
+                    if hasattr(item, _K) and not hasattr(item, 'ddt_cases'):
+                        meta[_A].append(item())
+                    elif hasattr(item, 'ddt_cases'):
+                        for caseData in item.ddt_cases:
+                            case = item();
+                            case.name, case.para = caseData[_K], caseData['para'];
+                            meta[_A].append(case)
+                    else:
+                        item.name = name;
+                        meta[_A].append(item())
+                else:
+                    cls_ddt_cases = module.__dict__['cls_ddt_cases']
+                    for cls_data in cls_ddt_cases:
+                        if hasattr(item, _K) and not hasattr(item, 'ddt_cases'):
+                            case = item()
+                            case.cls_para = cls_data['cls_para']
+                            case.name = f"{cls_data['cls_name']}-{case.name}"
+                            meta[_A].append(case)
+                        elif hasattr(item, 'ddt_cases'):
+                            for caseData in item.ddt_cases:
+                                case = item()
+                                case.cls_para = cls_data['cls_para']
+                                case.name, case.para = f"{cls_data['cls_name']}-{caseData[_K]}", caseData['para'];
+                                meta[_A].append(case)
+                        else:
+                            case = item()
+                            case.cls_para = cls_data['cls_para']
+                            case.name = f"{cls_data['cls_name']}-{name}"
+                            meta[_A].append(case)
+        new_suite_tag_table = {}
+        for (tname, table) in cls.suite_tag_table.items(): new_suite_tag_table[tname] = {p: v for (p, v) in
+                                                                                         table.items() if
+                                                                                         filepath.startswith(p)}
+        cls.suite_tag_table = new_suite_tag_table
+        if caseType:
+            if not meta[_A]: signal.debug(f"\n--- finally, no cases in this module , skip it.");return
+            cls.caseFilter(filepath, meta, tag_include_expr, tag_exclude_expr, suitename_filters, casename_filters)
+            if not meta[_A]: signal.debug(f"\n--- finally, no cases in this module , skip it.");return
+        elif len(meta) == 1:
+            signal.debug(f"\n--- finally, no setup/teardown/tags in this module , skip it.");return
+        cls.exec_list.append(filepath);
+        cls.exec_table[filepath] = meta
+
+    @classmethod
+    def caseFilter(cls, filepath, meta, tag_include_expr, tag_exclude_expr, suitename_filters, casename_filters):
+        if not tag_include_expr and not tag_exclude_expr and not suitename_filters and not casename_filters: return
+        if not tag_exclude_expr and suitename_filters:
+            suitenames = filepath.split(os.path.sep);
+            suitenames = [sn[:-3] if sn.endswith(_P) else sn for sn in suitenames]
+            if cls._patternMatch(suitenames, suitename_filters): return
+        passedCases = []
+        for caseClass in meta[_A]:
+            signal.debug(f"\n* {caseClass.name}");
+            suite_tags = [t for tl in cls.suite_tag_table[_H].values() for t in tl];
+            case_tags = getattr(caseClass, 'tags', []);
+            cls.current_case_tags = set(suite_tags + case_tags)
+            if tag_exclude_expr:
+                if eval(tag_exclude_expr) == _B:
+                    signal.debug(f"excluded for meeting expr : {tag_exclude_expr}");continue
+                elif not casename_filters and not suitename_filters and not tag_include_expr:
+                    passedCases.append(caseClass);continue
+            if casename_filters:
+                caseName = getattr(caseClass, _K)
+                if cls._patternMatch([caseName], casename_filters): passedCases.append(caseClass);continue
+            if tag_include_expr:
+                if eval(tag_include_expr) == _B: passedCases.append(caseClass);continue
+            signal.debug(f"excluded for not meet any include rules")
+        meta[_A] = passedCases
+
+    @classmethod
+    def _patternMatch(cls, names, patterns):
+        for name in names:
+            for pattern in patterns:
+                if fnmatch.fnmatch(name, pattern): return _B
+        return _C
+
+
 class Runner:
-	@classmethod
-	def run(cls):
-		if not Collector.exec_list:signal.criticalInfo('没有可以执行的测试用例');return 2
-		cls.caseId=0
-		for (name,meta) in Collector.exec_table.items():
-			if meta[_G]==_J and _E in meta:cls._insertTeardownToExecList(name)
-		signal.testStart();cls.execTest();signal.testEnd();from hytest.common import GSTORE;return GSTORE['---ret---']
-	@classmethod
-	def execTest(cls):
-		A='suite';suite_setup_failed_list=[]
-		for name in Collector.exec_list:
-			affected=_C
-			for suite_setup_failed in suite_setup_failed_list:
-				if name.startswith(suite_setup_failed):affected=_B;break
-			if affected:continue
-			if name.endswith(_L):
-				name=name.replace(_L,'');suite_teardown=Collector.exec_table[name][_E];signal.teardown(name,A)
-				try:suite_teardown()
-				except Exception as e:signal.teardown_fail(name,A,e,traceback.format_exc())
-			else:
-				meta=Collector.exec_table[name]
-				if meta[_G]==_J:
-					signal.enter_suite(name,'dir');suite_setup=meta.get(_I)
-					if suite_setup:
-						signal.setup(name,A)
-						try:suite_setup()
-						except Exception as e:signal.setup_fail(name,A,e,traceback.format_exc());suite_setup_failed_list.append(name)
-				elif meta[_G]==_Q:
-					signal.enter_suite(name,'file');suite_setup=meta.get(_I)
-					if suite_setup:
-						signal.setup(name,A)
-						try:suite_setup()
-						except Exception as e:signal.setup_fail(name,A,e,traceback.format_exc());continue
-					cls._exec_cases(meta);suite_teardown=meta.get(_E)
-					if suite_teardown:
-						signal.teardown(name,A)
-						try:suite_teardown()
-						except Exception as e:signal.teardown_fail(name,A,e,traceback.format_exc())
-	@classmethod
-	def _insertTeardownToExecList(cls,stName):
-		findStart=_C;insertPos=-1
-		for (pos,name) in enumerate(Collector.exec_list):
-			if not findStart:
-				if name!=stName:continue
-				else:findStart=_B
-			elif not name.startswith(stName):insertPos=pos;break
-		tearDownName=stName+_L
-		if insertPos==-1:Collector.exec_list.append(tearDownName)
-		else:Collector.exec_list.insert(insertPos,tearDownName)
-	@classmethod
-	def _exec_cases(cls,meta):
-		B='case_default';A='case';test_setup=meta.get(_N);test_teardown=meta.get(_O)
-		for case in meta[_A]:
-			case_className=type(case).__name__;cls.caseId+=1;signal.enter_case(cls.caseId,case.name,case_className);caseSetup=getattr(case,'setup',_F)
-			if caseSetup:
-				signal.setup(case.name,A)
-				try:caseSetup()
-				except Exception as e:signal.setup_fail(case.name,A,e,traceback.format_exc());continue
-			elif test_setup:
-				signal.setup(case.name,B)
-				try:test_setup()
-				except Exception as e:signal.setup_fail(case.name,B,e,traceback.format_exc());continue
-			signal.case_steps(case.name)
-			try:case.teststeps();signal.case_pass(cls.caseId,case.name)
-			except AssertionError as e:signal.case_fail(cls.caseId,case.name,e,traceback.format_exc())
-			except Exception as e:signal.case_abort(cls.caseId,case.name,e,traceback.format_exc())
-			caseTeardown=getattr(case,'teardown',_F)
-			if caseTeardown:
-				signal.teardown(case.name,A)
-				try:caseTeardown()
-				except Exception as e:signal.teardown_fail(case.name,A,e,traceback.format_exc())
-			elif test_teardown:
-				signal.teardown(case.name,B)
-				try:test_teardown()
-				except Exception as e:signal.teardown_fail(case.name,B,e,traceback.format_exc())
-if __name__=='__main__':Collector.run();Runner.run()
+    @classmethod
+    def run(cls):
+        if not Collector.exec_list: signal.criticalInfo('没有可以执行的测试用例');return 2
+        cls.caseId = 0
+        for (name, meta) in Collector.exec_table.items():
+            if meta[_G] == _J and _E in meta: cls._insertTeardownToExecList(name)
+        signal.testStart()
+        cls.execTest()
+        signal.testEnd()
+        from hytest.common import GSTORE
+        return GSTORE['---ret---']
+
+    @classmethod
+    def execTest(cls):
+        A = 'suite';
+        suite_setup_failed_list = []
+        for name in Collector.exec_list:
+            affected = _C
+            for suite_setup_failed in suite_setup_failed_list:
+                if name.startswith(suite_setup_failed): affected = _B;break
+            if affected: continue
+            if name.endswith(_L):
+                name = name.replace(_L, '');
+                suite_teardown = Collector.exec_table[name][_E];
+                signal.teardown(name, A)
+                try:
+                    suite_teardown()
+                except Exception as e:
+                    signal.teardown_fail(name, A, e, traceback.format_exc())
+            else:
+                meta = Collector.exec_table[name]
+                if meta[_G] == _J:
+                    signal.enter_suite(name, 'dir');
+                    suite_setup = meta.get(_I)
+                    if suite_setup:
+                        signal.setup(name, A)
+                        try:
+                            suite_setup()
+                        except Exception as e:
+                            signal.setup_fail(name, A, e, traceback.format_exc());suite_setup_failed_list.append(name)
+                elif meta[_G] == _Q:
+                    signal.enter_suite(name, 'file');
+                    suite_setup = meta.get(_I)
+                    if suite_setup:
+                        signal.setup(name, A)
+                        try:
+                            suite_setup()
+                        except Exception as e:
+                            signal.setup_fail(name, A, e, traceback.format_exc());continue
+                    cls._exec_cases(meta);
+                    suite_teardown = meta.get(_E)
+                    if suite_teardown:
+                        signal.teardown(name, A)
+                        try:
+                            suite_teardown()
+                        except Exception as e:
+                            signal.teardown_fail(name, A, e, traceback.format_exc())
+
+    @classmethod
+    def _insertTeardownToExecList(cls, stName):
+        findStart = _C;
+        insertPos = -1
+        for (pos, name) in enumerate(Collector.exec_list):
+            if not findStart:
+                if name != stName:
+                    continue
+                else:
+                    findStart = _B
+            elif not name.startswith(stName):
+                insertPos = pos;break
+        tearDownName = stName + _L
+        if insertPos == -1:
+            Collector.exec_list.append(tearDownName)
+        else:
+            Collector.exec_list.insert(insertPos, tearDownName)
+
+    @classmethod
+    def _exec_cases(cls, meta):
+        B = 'case_default';
+        A = 'case';
+        test_setup = meta.get(_N);
+        test_teardown = meta.get(_O)
+        for case in meta[_A]:
+            case_className = type(case).__name__;
+            cls.caseId += 1;
+            signal.enter_case(cls.caseId, case.name, case_className);
+            caseSetup = getattr(case, 'setup', _F)
+            if caseSetup:
+                signal.setup(case.name, A)
+                try:
+                    caseSetup()
+                except Exception as e:
+                    signal.setup_fail(case.name, A, e, traceback.format_exc());continue
+            elif test_setup:
+                signal.setup(case.name, B)
+                try:
+                    test_setup()
+                except Exception as e:
+                    signal.setup_fail(case.name, B, e, traceback.format_exc());continue
+            signal.case_steps(case.name)
+            try:
+                case.teststeps();signal.case_pass(cls.caseId, case.name)
+            except AssertionError as e:
+                signal.case_fail(cls.caseId, case.name, e, traceback.format_exc())
+            except Exception as e:
+                signal.case_abort(cls.caseId, case.name, e, traceback.format_exc())
+            caseTeardown = getattr(case, 'teardown', _F)
+            if caseTeardown:
+                signal.teardown(case.name, A)
+                try:
+                    caseTeardown()
+                except Exception as e:
+                    signal.teardown_fail(case.name, A, e, traceback.format_exc())
+            elif test_teardown:
+                signal.teardown(case.name, B)
+                try:
+                    test_teardown()
+                except Exception as e:
+                    signal.teardown_fail(case.name, B, e, traceback.format_exc())
+
+
+if __name__ == '__main__': Collector.run();Runner.run()


### PR DESCRIPTION
1.增加U2截图选项（也在CHECK_POINT中添加了）
2.增加 -W 命令，用于注册监控函数
   _-W watch.py
    例子  监控函数只识别 以watch开头命名的函数_
 
![1634178625(1)](https://user-images.githubusercontent.com/46307844/137240708-aa20a815-cf8b-413b-9c48-f5b73156e8ad.jpg)

3.增加状态恢复，即记录执行的suite_setup 当app 或者 页面异常崩溃时，重新执行suite_setup
4.代码中还存在cls_ddt_cases这个 ，感觉用的比较少。原理于ddt_cases一样
5.以上代码执行过程中暂未发现明显bug


